### PR TITLE
Added new script to start the project11 robotic environment. 

### DIFF
--- a/autostart_mystique.bash
+++ b/autostart_mystique.bash
@@ -2,7 +2,7 @@
 
 # inspired by: https://answers.ros.org/question/140426/issues-launching-ros-on-startup/
 
-LOG_FILE=/home/field/project11/log/autostart.txt
+LOG_FILE=${HOME}/project11/log/autostart.txt
 
 echo "" >> ${LOG_FILE}
 echo "#############################################" >> ${LOG_FILE}
@@ -23,5 +23,6 @@ set -e
 set -v
 
 {
-screen -d -m bash /home/field/project11/scripts/start_roslaunch_mystique.sh
+#screen -d -m bash /home/field/project11/scripts/start_roslaunch_mystique.sh
+screen -d -m bash /home/field/project11/scripts/start_project11.sh
 } &>> ${LOG_FILE}

--- a/start_project11.sh
+++ b/start_project11.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# A script to start the project11 autnoomous system backseat driver.
+#
+# Val Schmidt
+# Center for Coastal and Ocean Mapping
+# School of Marine Science and Ocean Engineering
+# University of New Hampshire
+# 2019
+
+LAUNCH_LOG_FILE=${HOME}/project11/log/project11_launch_log.txt
+
+# Check to see if we are executing in simulation mode. 
+if [ "$1" == '-sim' ]; then 
+	SIM=1
+elif [ "$1" == '' ]; then
+	SIM=0
+else 
+	echo "USAGE:"
+	echo "    ./start_project11.sh [-sim]"
+	exit
+fi
+
+# Setup path names for ROS and NODE log files.
+LOGDIR="${HOME}/project11/log"
+LAUNCHDIRNAME=`date -u --iso-8601=seconds | sed 's/\:/-/g'`
+LOGDIR_FULLPATH="${LOGDIR}/${LAUNCHDIRNAME}"
+
+# Log some header information.
+touch "${LAUNCH_LOG_FILE}"
+echo "" >> ${LAUNCH_LOG_FILE}
+echo "############################################################" >> ${LAUNCH_LOG_FILE}
+if [ "${SIM}" == 1 ]; then
+	echo "Running start_project11.sh Simulation Mode :: ${LAUNCHDIRNAME}" >> ${LAUNCH_LOG_FILE}
+else
+	echo "Running start_project11.sh :: ${LAUNCHDIRNAME}" >> ${LAUNCH_LOG_FILE}
+fi
+echo "############################################################" >> ${LAUNCH_LOG_FILE}
+echo "" >> ${LAUNCH_LOG_FILE}
+
+## Set up log directoires. 
+echo "CREATING LOG DIRECTORIES: ${LOGDIR_FULLPATH}" >> ${LAUNCH_LOG_FILE}
+mkdir -p "${LOGDIR_FULLPATH}/moos"
+mkdir -p "${LOGDIR_FULLPATH}/ros/nodes"
+
+cd "${LOGDIR}"
+ln -s "${LOGDIR_FULLPATH}" latest
+
+# Update links to new log location(s).
+#cd "${LOGDIR_FULLPATH}"
+
+# Remove old links.
+#if [ -L "nodes" ]; then
+#	rm nodes
+#fi
+#if [ -L "moos" ]; then
+#	rm moos
+#fi
+# Create new links.
+#ln -s "${LOGDIR_FULLPATH}/nodes"
+#ln -s "${LOGDIR_FULLPATH}/moos"
+
+# If this script has been run already, then ${HOME}/.ros will have been 
+# moved to a previous log directory and ${HOME}/.ros will be a soft link
+# to that place. In that case, we remove the soft link before creating
+# a new one to the new log location. 
+if [ -L "${HOME}/.ros" ]; then
+	rm "${HOME}/.ros"
+else
+	# If this script has not been run in the past (a new install), then ${HOME}/.ros 
+	# will be a directory and it should be moved to the new log directory.
+	mv "${HOME}/.ros" "${LOGDIR_FULLPATH}/ros"
+fi
+
+ln -s "${LOGDIR_FULLPATH}/ros" "${HOME}/.ros"
+
+
+set -e
+{
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
+source "${HOME}/project11/catkin_ws/devel/setup.bash"
+export ROS_WORKSPACE="${HOME}/project11/catkin_ws"
+} &>> ${LAUNCH_LOG_FILE}
+
+# Launch ROS
+if [ "${SIM}" == 1 ]; then
+	echo "Executing in Simulation Mode." >> ${LAUNCH_LOG_FILE}
+	{
+	roslaunch project11 sim_local.launch
+	} &>> ${LAUNCH_LOG_FILE}
+
+
+else
+	{
+	echo "Executing in Live Mode." >> ${LAUNCH_LOG_FILE}
+	roslaunch project11 mystique.launch
+	} &>> ${LAUNCH_LOG_FILE}
+fi

--- a/start_project11.sh
+++ b/start_project11.sh
@@ -44,6 +44,10 @@ mkdir -p "${LOGDIR_FULLPATH}/moos"
 mkdir -p "${LOGDIR_FULLPATH}/ros/nodes"
 
 cd "${LOGDIR}"
+
+if [ -L latest ]; then
+	rm latest
+fi
 ln -s "${LOGDIR_FULLPATH}" latest
 
 # Update links to new log location(s).


### PR DESCRIPTION
This new script `start_project11.sh` creates a new log directory on each startup with a name having the UTC timestamp, managing the .ros softlink as necessary. This should greatly aid in management of log files during operations and archival. The script then runs roslaunch redirecting the resulting output to project11/log/project11_launch_log.txt. The script accepts one optional arugment -sim to start project11 in a simulation environment in lieu of a live environment (the default). 

Also, autostart_msytique.bash was modified to call the new startup script. The old start_roslaunch_mystique.sh script, now deprecated, has not been modified or removed, yet.

One odd thing about it is that it seems to buffer the output of the roslaunch command indefinitely and does not write its output to the log file until Ctrl-C is executed on termination. I haven't been able to figure out why yet.